### PR TITLE
Add Music Player component and context to manage state

### DIFF
--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -1,0 +1,45 @@
+import { Card, Box } from "@mui/material";
+import SpotifyPlayer from "react-spotify-web-playback";
+import toast from "react-hot-toast";
+import { useContext } from "react";
+import { AppContext } from "../App";
+
+export default function MusicPlayer() {
+  const { songOnPlayer, spotifyApi } = useContext(AppContext);
+  const token = spotifyApi.getAccessToken();
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        padding: 1,
+        justifyContent: "center",
+        alignContent: "center",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "center",
+          alignContent: "center",
+        }}
+      >
+        <SpotifyPlayer
+          token={token!}
+          uris={songOnPlayer}
+          play={true}
+          layout="responsive"
+          hideAttribution={true}
+          callback={(state) => {
+            if (state.error === "Authentication failed") {
+              toast("Token expired please login again");
+              localStorage.removeItem("token");
+              window.location.reload();
+            }
+          }}
+        />
+        <Box></Box>
+      </Box>
+    </Card>
+  );
+}

--- a/src/helpers/getAuthParamsFromHash.ts
+++ b/src/helpers/getAuthParamsFromHash.ts
@@ -1,15 +1,13 @@
 // This is part of the authentication code used to obtain a token from Spotify during login.
-interface Token {
+interface AuthParams {
   [key: string]: string;
 }
 
-export default function getTokenFromUrl() {
+export default function getAuthParamsFromHash() {
   return window.location.hash
     .substring(1)
     .split("&")
-    .reduce((initial: Token, item: string) => {
-      console.log(initial);
-      console.log(item);
+    .reduce((initial: AuthParams, item: string) => {
       const parts = item.split("=");
       initial[parts[0]] = decodeURIComponent(parts[1]);
       return initial;

--- a/src/helpers/getAuthParamsFromHash.ts
+++ b/src/helpers/getAuthParamsFromHash.ts
@@ -1,15 +1,12 @@
 // This is part of the authentication code used to obtain a token from Spotify during login.
-interface AuthParams {
-  [key: string]: string;
-}
-
-export default function getAuthParamsFromHash() {
-  return window.location.hash
+export default function getTokenFromUrl() {
+  const urlHashParams = window.location.hash
     .substring(1)
     .split("&")
-    .reduce((initial: AuthParams, item: string) => {
+    .reduce((initial, item) => {
       const parts = item.split("=");
       initial[parts[0]] = decodeURIComponent(parts[1]);
       return initial;
-    }, {});
-}
+    }, {} as Record<string, string | undefined>);
+  
+    return urlHashParams.access_token;

--- a/src/helpers/handleExpiredToken.ts
+++ b/src/helpers/handleExpiredToken.ts
@@ -1,0 +1,14 @@
+import toast from "react-hot-toast";
+interface HttpError extends Error {
+  status?: number;
+}
+
+export function handleExpiredToken(error: HttpError) {
+  if (error.status === 401) {
+    toast("Token expired please login again");
+    localStorage.removeItem("token");
+    window.location.reload();
+  } else {
+    throw error;
+  }
+}

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,6 +1,5 @@
 import { useRouteError } from "react-router-dom";
 export default function ErrorPage() {
-  const error = useRouteError();
-
-  return <div>{error ? "Error message" : "no Error"}</div>;
+  const error = useRouteError() as Error;
+  return <div>{error.message ? error.message : "Page not found"}</div>;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+import MusicPlayer from "../components/MusicPlayer";
 
 export default function HomePage() {
   return (
@@ -8,7 +9,7 @@ export default function HomePage() {
       justifyContent="center"
       minHeight={500}
     >
-      Add Music player here
+      <MusicPlayer />
     </Box>
   );
 }


### PR DESCRIPTION
This pull request 
adds a music player component that uses the react-spotify-web-playback library to create a Spotify player component. 
I added context to manage state and updated the function name from getTokenFromUrl() to getAuthParamsFromHash() to clarify that it's not just returning the token.
 I can't remember how you refactored this function during our call. Could you please share with me the way you did it?"